### PR TITLE
Ensure setuptools version <=58

### DIFF
--- a/setup_ba_env.sh
+++ b/setup_ba_env.sh
@@ -1,6 +1,7 @@
 ### create satnerf venv
 conda create -n ba -c conda-forge python=3.8
 conda activate ba
+python3 -m pip install --force-reinstall -v "setuptools<=58"
 python3 -m pip install git+https://github.com/centreborelli/sat-bundleadjust
 pip install fire
 #pip install "pyproj>=2.0.2,<3.0.0"


### PR DESCRIPTION
Resolves issue with setuptools loss of support for "use_2to3".
Resolves "pip install sat-bundleadjust" issue "error in ad setup command: use_2to3 is invalid."